### PR TITLE
Ability to handle single host queries and CVL's

### DIFF
--- a/dynatrace_api.py
+++ b/dynatrace_api.py
@@ -134,7 +134,7 @@ class DynatraceApi:
         """
         ids = entityId.split(',')
         entityIds = ', '.join(f'"{i}"' for i in ids)
-        return self.getAllEntities('/api/v2/entities?pageSize=500&fields=+toRelationships.isProcessOf&entitySelector=entityId('+entityIds+')&from='+timeframe)
+        return self.getAllEntities('/api/v2/entities?pageSize=500&fields=+toRelationships.isProcessOf,managementZones,properties.memoryTotal,properties.monitoringMode&entitySelector=entityId('+entityIds+')&from='+timeframe)
 
     def getAllEntitiesByIDs(self, endpoint, entityRefs):
         """

--- a/vulnerabilities_by_host.py
+++ b/vulnerabilities_by_host.py
@@ -48,7 +48,12 @@ def getCmdPath(process):
         return ""
 #added host[managementzone] SRS
 def fieldsToPrint(host, process, securityProblem):
-    cve = ''.join(securityProblem['cveIds'])
+
+    if 'cveIds' in securityProblem:
+        cve = ''.join(securityProblem['cveIds'])
+    else:
+        cve = ''
+
     return [host['displayName'],
         host['entityId'],
         host['managementZones'],
@@ -62,8 +67,8 @@ def fieldsToPrint(host, process, securityProblem):
         securityProblem['url'],
         securityProblem['riskAssessment']['riskLevel'],
         securityProblem['riskAssessment']['riskScore'],
-        securityProblem['riskAssessment']['baseRiskLevel'],
-        securityProblem['riskAssessment']['baseRiskScore'],
+        securityProblem.get('riskAssessment', {}).get('baseRiskLevel', ''),
+        securityProblem.get('riskAssessment', {}).get('baseRiskScore', ''),
         getMetadata(process, 'EXE_PATH'),
         getMetadata(process, 'COMMAND_LINE_ARGS'), 
         getCmdPath(process)


### PR DESCRIPTION
Mirrored the fields returned by the getHostsById() to the same as getHosts() as calling for a single host would fail because managementZones were not being returned.

Added capabilities to deal with CLV's which don't have CVE's or properties like baseRiskLevel or baseRiskScore